### PR TITLE
[Fix] README, DEPENDENCY, and minor bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,27 +65,6 @@ by default but can be overridden by setting the component parameter `tof`.
 | `tof`           | `HighTime`, `LowTime` |
 
 
-# `Readout.comp`: Subprocess EFU, CAEN electronics [deprecated]
-Using `EFU` produced `HDF5` files along with `mcrun` type scans requires that the `EFU` be stopped after every scan point.
-This component can control the execution of a local `EFU` by starting it in a subprocess and instructing it to stop
-via its command-port interface.
-
-At the moment, it only supports CAEN instruments and should probably not be used going forward.
-
-## McStas Component specific parameters
-| Parameter        | Type   | Description                                                                             |
-|------------------|--------|-----------------------------------------------------------------------------------------|
-| `tube`           | named  | identifies the pair of digitizers connected to the channel                              |
-| `a`              | named  | is the integrated voltage output of the first digitizer                                 |
-| `b`              | named  | is the integrated voltage output of the second digitizer                                |
-| `receiver`       | string | the path to the EFU executable, required if it is to be started locally                 |
-| `options`        | string | command-line options used when starting the EFU                                         |
-| `filename`       | string | filename for events if EFU started and output requested, `NAME_CURRENT_COMP` by default |
-| `hdf5_output`    | int    | flag to control dumping EFU-received events if EFU started, on by default               |
-| `start_receiver` | int    | flag to control whether the local EFU should be started, on by default                  |
-
-
-
 # `ReadoutCAEN.comp`: instruments with CAEN electronics
 
 At least four ESS instruments will use CAEN digitizers to read out the detector signals.
@@ -100,10 +79,10 @@ which makes use of an EFU, a Kafka broker and independent file writers; all mana
 | Parameter   | Type  | Description                                                 |
 |-------------|-------|-------------------------------------------------------------|
 | `tube`      | named | identifies the group of digitizers connected to the channel |
-| `a`         | named | is the integrated voltage output of the first digitizer     |
-| `b`         | named | is the integrated voltage output of the second digitizer    |
-| `c`         | named | is the integrated voltage output of the third digitizer     |
-| `d`         | named | is the integrated voltage output of the fourth digitizer    |
+| `a_name`    | named | is the integrated voltage output of the first digitizer     |
+| `b_name`    | named | is the integrated voltage output of the second digitizer    |
+| `c_name`    | named | is the integrated voltage output of the third digitizer     |
+| `d_name`    | named | is the integrated voltage output of the fourth digitizer    |
 | `fen_value` | int   | used for `FENId` if no named `fen` parameter                |
 | `a_value`   | int   | used when `a` is not named; default 0                       |
 | `b_value`   | int   | used when `b` is not named; default 0                       |
@@ -120,10 +99,10 @@ which are therefore required as input to the CAEN EFU  as `AmpA` and `AmpB`.
 | Named parameter | EFU parameter |
 |-----------------|---------------|
 | `tube`          | `GroupId`     |
-| `a`             | `AmpA`        |
-| `b`             | `AmpB`        |
-| `c`             | `AmpC`        |
-| `d`             | `AmpD`        |
+| `a_name`        | `AmpA`        |
+| `b_name`        | `AmpB`        |
+| `c_name`        | `AmpC`        |
+| `d_name`        | `AmpD`        |
 
 
 # `ReadoutTTLMonitor.comp`: simple TTL based beam monitors

--- a/components/ReadoutCAEN.comp
+++ b/components/ReadoutCAEN.comp
@@ -8,7 +8,7 @@ string a_name = 0,
 string b_name = 0,
 string c_name = 0,
 string d_name = 0,
-string tof_name = "t",
+string tof = "t",
 string ip = 0,
 int fen_value=0,
 int a_value=0,
@@ -29,7 +29,7 @@ int verbose=0, // -1: silent, 0: errors, 1: warnings, 2: info, 3: details
 int ess_type=52 // 0x34 == 52, 0x41==65
 )
 OUTPUT PARAMETERS ()
-DEPENDENCY "-Wl,-rpath,CMD(readout-config --show libdir) -LCMD(readout-config --show libdir) -lReadout -ICMD(readout-config --show includedir)"
+DEPENDENCY "-Wl,-rpath,CMD(readout-config --show libdir) -LCMD(readout-config --show libdir) -lreadout -ICMD(readout-config --show includedir)"
 SHARE
 %{
 #include <signal.h>
@@ -142,7 +142,7 @@ if (d_present){
   particle_getvar(_particle, d_name, &failure);
   if (failure) readout_caen_error(NAME_CURRENT_COMP, d_name);
 }
-particle_getvar(_particle, tof_name, &failure); if (failure) readout_caen_error(NAME_CURRENT_COMP,  tof_name);
+particle_getvar(_particle, tof, &failure); if (failure) readout_caen_error(NAME_CURRENT_COMP,  tof);
 
 p_or_pp = (strcmp(event_mode, "p") == 0) ? 0 : 1;
 if (p_or_pp && !strcmp(event_mode, "pp")) readout_caen_error(NAME_CURRENT_COMP, "Undefined event mode");
@@ -169,7 +169,7 @@ if (event_count) {
   int_B = b_present ? readout_caen_particle_getvar_int(_particle, b_name) : b_value;
   int_C = c_present ? readout_caen_particle_getvar_int(_particle, c_name) : c_value;
   int_D = d_present ? readout_caen_particle_getvar_int(_particle, d_name) : d_value;
-  double_tof = particle_getvar(_particle, tof_name, 0);
+  double_tof = particle_getvar(_particle, tof, 0);
 } else {
   int_ring = (int)(rand01() * 3);
   int_tube = (int)(rand01() * 15);

--- a/components/ReadoutTTLMonitor.comp
+++ b/components/ReadoutTTLMonitor.comp
@@ -27,7 +27,7 @@ int ess_type=16, // TTLMonitor should always be 0x10 == 16
 double efficiency=1
 )
 OUTPUT PARAMETERS ()
-DEPENDENCY "-Wl,-rpath,CMD(readout-config --show libdir) -LCMD(readout-config --show libdir) -lReadout -ICMD(readout-config --show includedir)"
+DEPENDENCY "-Wl,-rpath,CMD(readout-config --show libdir) -LCMD(readout-config --show libdir) -lreadout -ICMD(readout-config --show includedir)"
 SHARE
 %{
 #include <signal.h>
@@ -108,7 +108,7 @@ if ((filename != NULL) && (filename[0] != '\0')){
   this_filename = mcfull_file(actual_filename, NULL);
   // release the memory now that we have the full filename
   if (actual_filename) free(actual_filename);
-  readout_dump_to(this_filename);
+  readout_dump_to(readout_ptr, this_filename);
 }
 
 


### PR DESCRIPTION
Part of #9 

- `README.md` has been amended to remove mention of `Readout.comp`, which has been removed, and to update the list of component setting parameter names.
- The components' `DEPENDENCY` line have been corrected to link to `-lreadout`.
- `ReadouCAEN.comp` again uses `tof` instead of `tof_name`.
- `ReadoutTTLMonitor.com` has its call to the file-output routine corrected.

