### PR TITLE
Poisson resampled events

### DIFF
--- a/components/ReadoutCAEN.comp
+++ b/components/ReadoutCAEN.comp
@@ -51,14 +51,6 @@ SHARE
       double bits = particle_getvar(p, name, 0);
       return *(int*)&bits;
   }
-  int readout_caen_rand_poisson(double rate){
-    //double rand_exp = -log(rand01()) / rate;
-    double criteria = exp(-rate);
-    int count=0;
-    double prod=1;
-    while ((prod *= rand01()) > criteria) ++count;
-    return count;
-  }
 %}
 
 DECLARE
@@ -151,17 +143,13 @@ if (p_or_pp && !strcmp(event_mode, "pp")) readout_caen_error(NAME_CURRENT_COMP, 
 
 TRACE
 %{
-double pp = particle_getvar(_particle, "p", 0) * sqrt((double)(mcget_ncount()));
+double pp = particle_getvar(_particle, "p", 0); // * sqrt((double)(mcget_ncount()));
 if (p_or_pp) pp *= pp;
-
-int event_count = readout_caen_rand_poisson(pp);
-
-int is_noise = (!event_count && noisy && rand01() < noise_level) ? 1 : 0;
 
 int int_ring, int_fen, int_tube, int_A, int_B, int_C, int_D;
 double double_tof;
 
-if (event_count) {
+if (pp) {
   int_ring = readout_caen_particle_getvar_int(_particle, ring);
   int_fen = fen_present ? readout_caen_particle_getvar_int(_particle, fen) : fen_value;
   int_tube = readout_caen_particle_getvar_int(_particle, tube);
@@ -181,24 +169,19 @@ if (event_count) {
   double_tof = rand01() / pulse_rate;
 }
 
-if (is_noise) event_count = 1;
+// add error checking of int -> uintN_t values?
+uint8_t RING = (uint8_t)int_ring;
+uint8_t FEN = (uint8_t)int_fen;
+readout_data.channel = (uint8_t)int_tube;
+readout_data.a = (uint16_t)int_A;
+readout_data.b = (uint16_t)int_B;
+readout_data.c = (uint16_t)int_C;
+readout_data.d = (uint16_t)int_D;
+if (verbose > 2)
+  printf("(%2u %2u %2u) %5u %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.channel, readout_data.a, readout_data.b, double_tof, event_count);
+// Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
+readout_add(readout_ptr, RING, FEN, double_tof, pp, (const void *)(&readout_data));
 
-if (event_count) {
-  // add error checking of int -> uintN_t values?
-  uint8_t RING = (uint8_t)int_ring;
-  uint8_t FEN = (uint8_t)int_fen;
-  readout_data.channel = (uint8_t)int_tube;
-  readout_data.a = (uint16_t)int_A;
-  readout_data.b = (uint16_t)int_B;
-  readout_data.c = (uint16_t)int_C;
-  readout_data.d = (uint16_t)int_D;
-  if (verbose > 2)
-    printf("(%2u %2u %2u) %5u %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.channel, readout_data.a, readout_data.b, double_tof, event_count);
-  for (int i=0; i<1 /*event_count*/; ++i){
-    // Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
-    readout_add(readout_ptr, RING, FEN, double_tof, p_or_pp, (const void *)(&readout_data));
-  }
-}
 %}
 
 FINALLY

--- a/components/ReadoutTTLMonitor.comp
+++ b/components/ReadoutTTLMonitor.comp
@@ -49,14 +49,6 @@ SHARE
       double bits = particle_getvar(p, name, 0);
       return *(int*)&bits;
   }
-  int readout_ttlmonitor_rand_poisson(double rate){
-    //double rand_exp = -log(rand01()) / rate;
-    double criteria = exp(-rate);
-    int count=0;
-    double prod=1;
-    while ((prod *= rand01()) > criteria) ++count;
-    return count;
-  }
 %}
 
 DECLARE
@@ -140,18 +132,14 @@ if (p_or_pp && !strcmp(event_mode, "pp")) readout_ttlmonitor_error(NAME_CURRENT_
 
 TRACE
 %{
-double pp = particle_getvar(_particle, "p", 0) * sqrt((double)(mcget_ncount()));
+double pp = particle_getvar(_particle, "p", 0); // * sqrt((double)(mcget_ncount()));
 if (p_or_pp) pp *= pp;
 pp *= efficiency;
-
-int event_count = readout_ttlmonitor_rand_poisson(pp);
-
-int is_noise = (!event_count && noisy && rand01() < noise_level) ? 1 : 0;
 
 int int_ring, int_fen, int_pos, int_channel, int_adc;
 double double_tof;
 
-if (event_count) {
+if (pp) {
   int_ring = ring_present ? readout_ttlmonitor_particle_getvar_int(_particle, ring) : ring_value;
   int_fen = fen_present ? readout_ttlmonitor_particle_getvar_int(_particle, fen) : fen_value;
   int_pos = pos_present ? readout_ttlmonitor_particle_getvar_int(_particle, pos) : pos_value;
@@ -167,22 +155,17 @@ if (event_count) {
   double_tof = rand01() / pulse_rate;
 }
 
-if (is_noise) event_count = 1;
+// add error checking of int -> uintN_t values?
+uint8_t RING = (uint8_t)int_ring;
+uint8_t FEN = (uint8_t)int_fen;
+readout_data.pos = (uint8_t)int_pos;
+readout_data.channel = (uint8_t)int_channel;
+readout_data.adc = (uint16_t)int_adc;
+if (verbose > 2)
+  printf("(%2u %2u) (%2u %2u) %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.pos, readout_data.channel, readout_data.adc, double_tof, event_count);
+// Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
+readout_add(readout_ptr, RING, FEN, double_tof, pp, (const void *)(&readout_data));
 
-if (event_count) {
-  // add error checking of int -> uintN_t values?
-  uint8_t RING = (uint8_t)int_ring;
-  uint8_t FEN = (uint8_t)int_fen;
-  readout_data.pos = (uint8_t)int_pos;
-  readout_data.channel = (uint8_t)int_channel;
-  readout_data.adc = (uint16_t)int_adc;
-  if (verbose > 2)
-    printf("(%2u %2u) (%2u %2u) %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.pos, readout_data.channel, readout_data.adc, double_tof, event_count);
-  for (int i=0; i<1 /*event_count*/; ++i){
-    // Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
-    readout_add(readout_ptr, RING, FEN, double_tof, pp, (const void *)(&readout_data));
-  }
-}
 %}
 
 FINALLY

--- a/lib/Readout.cpp
+++ b/lib/Readout.cpp
@@ -136,6 +136,25 @@ void readout_enable_network(readout_t * r_ptr){
   return obj->enable_network();
 }
 
+void readout_rand_seed01(readout_t * r_ptr, const double seed){
+  Readout * obj;
+  if (r_ptr == nullptr) return;
+  obj = static_cast<Readout*>(r_ptr->obj);
+  return obj->set_random_seed(static_cast<uint32_t>(seed * UINT32_MAX));
+}
+void readout_rand_seed(readout_t * r_ptr, const uint32_t seed){
+  Readout * obj;
+  if (r_ptr == nullptr) return;
+  obj = static_cast<Readout*>(r_ptr->obj);
+  return obj->set_random_seed(seed);
+}
+int readout_rand_poisson(readout_t * r_ptr, const double mean){
+  Readout * obj;
+  if (r_ptr == nullptr) return 0;
+  obj = static_cast<Readout*>(r_ptr->obj);
+  return obj->random_poisson(mean);
+}
+
 
   // 
 #ifdef __cplusplus

--- a/lib/Readout.h
+++ b/lib/Readout.h
@@ -103,6 +103,12 @@ RL_API void readout_merge_files(const char * out_filename, const char ** in_file
 RL_API void readout_disable_network(readout_t * r_ptr);
 RL_API void readout_enable_network(readout_t * r_ptr);
 
+// Set the random seed for the readout random object
+RL_API void readout_rand_seed01(readout_t * r_ptr, double seed);
+RL_API void readout_rand_seed(readout_t * r_ptr, uint32_t seed);
+// Convert a probability to a discrete number of events
+RL_API int readout_rand_poisson(readout_t * r_ptr, double mean);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/ReadoutClass.h
+++ b/lib/ReadoutClass.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <utility>
 #include <optional>
+#include <random>
 
 #include "Structs.h"
 #include "Readout.h"
@@ -53,6 +54,8 @@ public:
   // Adds a readout to the transmission buffer.
   // If there is no room left, transmit and initialize a new packet
   void addReadout(uint8_t Ring, uint8_t FEN, double tof, double weight, const void * data);
+  // Add a single readout
+  void addReadout(uint8_t Ring, uint8_t FEN, efu_time t, const void * data);
   // Specializations for handled data types
   void addReadout(uint8_t Ring, uint8_t FEN, efu_time t, const CAEN_readout_t * data);
   void addReadout(uint8_t Ring, uint8_t FEN, efu_time t, const TTLMonitor_readout_t * data);
@@ -111,6 +114,15 @@ public:
   void enable_network() {network = true;}
   void disable_network() {network = false;}
 
+  void set_random_seed(const uint32_t seed) {
+    random_engine.seed(seed);
+  }
+
+  int random_poisson(const double mean) {
+    std::poisson_distribution<int> distribution(mean);
+    return distribution(random_engine);
+  }
+
 private:
   HighFive::CompoundType datatype() const {
     using namespace HighFive;
@@ -153,4 +165,6 @@ private:
   bool network{true};
   efu_time period, time;
   cluon::UDPSender sender;
+
+  std::mt19937 random_engine{std::default_random_engine{}()};
 };

--- a/test/readout_test.cpp
+++ b/test/readout_test.cpp
@@ -56,7 +56,8 @@ TEST_CASE("Send and receive CAEN packets","[c][CAEN]"){
       caen_data.b = max - i;
       caen_data.c = 0;
       caen_data.d = 0;
-      readout_add(detector_efu, ring, fen, tof, static_cast<double>(i), static_cast<const void *>(&caen_data));
+      // Setting the weight to 0, otherwise it is used to send a random number of packets
+      readout_add(detector_efu, ring, fen, tof, 0., static_cast<const void *>(&caen_data));
     }
     readout_destroy(detector_efu);
   }
@@ -111,10 +112,11 @@ TEST_CASE("Send and receive TTLMonitor packets","[c]"){
       ttl_data.pos = tube;
       ttl_data.channel = 0;
       ttl_data.adc = i;
-      readout_add(monitor_efu, 0, 100, tof, 1.0, static_cast<const void *>(&ttl_data));
+      // Setting the weight to 0, otherwise it is used to send a random number of packets
+      readout_add(monitor_efu, 0, 100, tof, 0.0, static_cast<const void *>(&ttl_data));
       ttl_data.channel = 1;
       ttl_data.adc = max - i;
-      readout_add(monitor_efu, 0, 100, tof, 2.0, static_cast<const void *>(&ttl_data));
+      readout_add(monitor_efu, 0, 100, tof, 0.0, static_cast<const void *>(&ttl_data));
     }
     readout_destroy(monitor_efu);
   }

--- a/test/replay_test.cpp
+++ b/test/replay_test.cpp
@@ -126,10 +126,10 @@ TEST_CASE("Store, replay and receive TTLMonitor packets","[c][TTLMonitor][io]"){
     ttl_data.pos = tube;
     ttl_data.channel = 0;
     ttl_data.adc = i;
-    readout_add(monitor_efu, 0, 100, tof, 1.0, static_cast<const void *>(&ttl_data));
+    readout_add(monitor_efu, 0, 100, tof, 0.0, static_cast<const void *>(&ttl_data));
     ttl_data.channel = 1;
     ttl_data.adc = max - i;
-    readout_add(monitor_efu, 0, 100, tof, 2.0, static_cast<const void *>(&ttl_data));
+    readout_add(monitor_efu, 0, 100, tof, 0.0, static_cast<const void *>(&ttl_data));
   }
   readout_send(monitor_efu);
   readout_destroy(monitor_efu);


### PR DESCRIPTION
- Move the random number of events per ray from the McStas side to the Readout side. This will allow for replaying these events without needing to store N identical events per ray.
- Add a std::poisson_distribution interface to ReadoutClass.
- Only zero-weight rays get converted to noise, and are always one event. This could be modified to allow for adjustable noise levels.
- Probabilities should be (partial) mean counts/second such that the sampled number of events corresponds to a probable count that would occur in one second. Maybe this should be scaled by the pulse period?