### PR TITLE
Improved testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ output2 = ReadoutTTLMonitor(channel_value=2, fen_value=100, adc="monitor_signal"
 ```
 
 ## Additional component parameters
-| Parameter       | Type  | Description                                        |
-|-----------------|-------|----------------------------------------------------|
-| `pos`           | named | detection position in monitor                      |
-| `channel`       | named | identifies the monitor                             |
-| `adc`           | named | the integrated voltage output of the digitizer     |
-| `ring_value`    | int   | used for `FibreId` if no named `ring` parameter    |
-| `fen_value`     | int   | used for `FENId` if no named `fen` parameter       |
-| `pos_value`     | int   | used for `Pos` if no named `pos` parameter         |
-| `channel_value` | int   | used for `Channel` if no named `channel` parameter |
+| Parameter        | Type  | Description                                         |
+|------------------|-------|-----------------------------------------------------|
+| `position`       | named | detection position in monitor                       |
+| `identity`       | named | identifies the monitor                              |
+| `output`         | named | the integrated voltage output of the digitizer      |
+| `ring_value`     | int   | used for `FibreId` if no named `ring` parameter     |
+| `fen_value`      | int   | used for `FENId` if no named `fen` parameter        |
+| `pos_value`      | int   | used for `Pos` if no named `position` parameter     |
+| `identity_value` | int   | used for `Channel` if no named `identity` parameter |
 
 
 # Installation

--- a/share/Readout/ReadoutCAEN.comp
+++ b/share/Readout/ReadoutCAEN.comp
@@ -178,7 +178,7 @@ readout_data.b = (uint16_t)int_B;
 readout_data.c = (uint16_t)int_C;
 readout_data.d = (uint16_t)int_D;
 if (verbose > 2)
-  printf("(%2u %2u %2u) %5u %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.channel, readout_data.a, readout_data.b, double_tof, event_count);
+  printf("(%2u %2u %2u) %5u %5u %0.10f -- Accumulated\n", RING, FEN, readout_data.channel, readout_data.a, readout_data.b, double_tof);
 // Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
 readout_add(readout_ptr, RING, FEN, double_tof, pp, (const void *)(&readout_data));
 

--- a/share/Readout/ReadoutTTLMonitor.comp
+++ b/share/Readout/ReadoutTTLMonitor.comp
@@ -3,15 +3,15 @@ DEFINITION PARAMETERS()
 SETTING PARAMETERS (
 string ring = 0,
 string fen = 0,
-string pos = 0,
-string channel = 0,
-string adc = 0,
+string position = 0,
+string identity = 0,
+string value = 0,
 string tof = "t",
 string ip = 0,
 int ring_value=0,
 int fen_value=0,
-int pos_value=0,
-int channel_value=0,
+int position_value=0,
+int identity_value=0,
 int port = 9000,
 int command_port = 10800,
 int broadcast = 1,
@@ -59,13 +59,13 @@ readout_t* readout_ptr;
 int p_or_pp;
 int ring_present;
 int fen_present;
-int pos_present;
-int channel_present;
+int position_present;
+int identity_present;
 %}
 
 INITIALIZE
 %{
-char extension[128] = '\0';
+char extension[128] = "\0";
 char * this_filename;
 
 // Include the header file and run any initialization for the real broadcaster
@@ -106,8 +106,8 @@ if ((filename != NULL) && (filename[0] != '\0')){
 
 ring_present = ((ring != NULL) && (ring[0] != '\0')) ? 1 : 0;
 fen_present = ((fen != NULL) && (fen[0] != '\0')) ? 1 : 0;
-pos_present = ((pos != NULL) && (pos[0] != '\0')) ? 1 : 0;
-channel_present = ((channel != NULL) && (channel[0] != '\0')) ? 1 : 0;
+position_present = ((position != NULL) && (position[0] != '\0')) ? 1 : 0;
+identity_present = ((identity != NULL) && (identity[0] != '\0')) ? 1 : 0;
 // Make sure the provided property names are accessible -- no error checking later
 int failure=0;
 if (ring_present){
@@ -116,13 +116,13 @@ if (ring_present){
 if (fen_present){
     particle_getvar(_particle, fen, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, fen);
 }
-if (pos_present){
-    particle_getvar(_particle, pos, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, pos);
+if (position_present){
+    particle_getvar(_particle, position, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, position);
 }
-if (channel_present){
-    particle_getvar(_particle, channel, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, channel);
+if (identity_present){
+    particle_getvar(_particle, identity, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, identity);
 }
-particle_getvar(_particle, adc, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, adc);
+particle_getvar(_particle, value, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, value);
 particle_getvar(_particle, tof, &failure); if (failure) readout_ttlmonitor_error(NAME_CURRENT_COMP, tof);
 
 p_or_pp = (strcmp(event_mode, "p") == 0) ? 0 : 1;
@@ -136,33 +136,33 @@ double pp = particle_getvar(_particle, "p", 0); // * sqrt((double)(mcget_ncount(
 if (p_or_pp) pp *= pp;
 pp *= efficiency;
 
-int int_ring, int_fen, int_pos, int_channel, int_adc;
+int int_ring, int_fen, int_position, int_identity, int_value;
 double double_tof;
 
 if (pp) {
   int_ring = ring_present ? readout_ttlmonitor_particle_getvar_int(_particle, ring) : ring_value;
   int_fen = fen_present ? readout_ttlmonitor_particle_getvar_int(_particle, fen) : fen_value;
-  int_pos = pos_present ? readout_ttlmonitor_particle_getvar_int(_particle, pos) : pos_value;
-  int_channel = channel_present ? readout_ttlmonitor_particle_getvar_int(_particle, channel) : channel_value;
-  int_adc = readout_ttlmonitor_particle_getvar_int(_particle, adc);
+  int_position = position_present ? readout_ttlmonitor_particle_getvar_int(_particle, position) : position_value;
+  int_identity = identity_present ? readout_ttlmonitor_particle_getvar_int(_particle, identity) : identity_value;
+  int_value = readout_ttlmonitor_particle_getvar_int(_particle, value);
   double_tof = particle_getvar(_particle, tof, 0);
 } else {
   int_ring = (int)(rand01());
   int_fen = 0;
-  int_pos = pos_value;
-  int_channel = channel_value;
-  int_adc = (int)(rand01() * 4096);
+  int_position = position_value;
+  int_identity = identity_value;
+  int_value = (int)(rand01() * 4096);
   double_tof = rand01() / pulse_rate;
 }
 
 // add error checking of int -> uintN_t values?
 uint8_t RING = (uint8_t)int_ring;
 uint8_t FEN = (uint8_t)int_fen;
-readout_data.pos = (uint8_t)int_pos;
-readout_data.channel = (uint8_t)int_channel;
-readout_data.adc = (uint16_t)int_adc;
+readout_data.pos = (uint8_t)int_position;
+readout_data.channel = (uint8_t)int_identity;
+readout_data.adc = (uint16_t)int_value;
 if (verbose > 2)
-  printf("(%2u %2u) (%2u %2u) %5u %0.10f -- Accumulated (x %d)\n", RING, FEN, readout_data.pos, readout_data.channel, readout_data.adc, double_tof, event_count);
+  printf("(%2u %2u) (%2u %2u) %5u %0.10f -- Accumulated\n", RING, FEN, readout_data.pos, readout_data.channel, readout_data.adc, double_tof);
 // Send the event to the broadcaster to be accumulated and broadcast and/or store the event to file
 readout_add(readout_ptr, RING, FEN, double_tof, pp, (const void *)(&readout_data));
 
@@ -200,7 +200,7 @@ MPI_Barrier(MPI_COMM_WORLD);
 
         /*remove the original unmerged files if wanted*/
         if(!keep_mpi_unmerged){
-          int status{=0;
+          int status=0;
           for (int j=0; j<mpi_node_count; j++)
             status += remove(merge_filenames[j]);
           if (status)
@@ -214,6 +214,7 @@ MPI_Barrier(MPI_COMM_WORLD);
       }
   );
 #endif
+}
 %}
 
 MCDISPLAY

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,10 @@
 file(GLOB CATCH_SOURCES *_test.cpp)
 target_sources(${READOUT_TESTER_TARGET} PRIVATE ${CATCH_SOURCES})
 target_include_directories(${READOUT_TESTER_TARGET} PRIVATE ${CMAKE_CURRENT_LIST_DIR})
+
+
+find_program(BASH_PROGRAM bash)
+if (BASH_PROGRAM)
+    add_test(integration "${BASH_PROGRAM}" "${CMAKE_CURRENT_SOURCE_DIR}/test_integration.sh")
+    set_tests_properties(integration PROPERTIES SKIP_RETURN_CODE 100)
+endif(BASH_PROGRAM)

--- a/test/readout_test.cpp
+++ b/test/readout_test.cpp
@@ -6,10 +6,39 @@
 #include <Structs.h>
 #include "test_utils.h"
 
+int find_port() {
+  int port = 0;
+  int sock = socket(PF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (sock < 0) {
+    perror("socket");
+    return -1;
+  }
+  struct sockaddr_in addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  addr.sin_port = htons(port);
+  if (bind(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    perror("bind");
+    close(sock);
+    return -1;
+  }
+  socklen_t len = sizeof(addr);
+  if (getsockname(sock, (struct sockaddr *)&addr, &len) == -1) {
+    perror("getsockname");
+    close(sock);
+    return -1;
+  }
+  port = ntohs(addr.sin_port);
+  close(sock);
+  return port;
+}
+
 TEST_CASE("Send and receive CAEN packets","[c][CAEN]"){
   const uint16_t max{1000};
   uint32_t detector_type{0x34};
-  int detector_port{9000};
+
+  int detector_port = find_port();
   auto stats = std::make_shared<UDPStats>();
 
   cluon::UDPReceiver detector_receiver("127.0.0.1", detector_port,
@@ -73,7 +102,7 @@ TEST_CASE("Send and receive CAEN packets","[c][CAEN]"){
 TEST_CASE("Send and receive TTLMonitor packets","[c]"){
   const uint16_t max{1000};
   uint32_t monitor_type{0x10};
-  int monitor_port{9001};
+  int monitor_port = find_port();
   auto stats = std::make_shared<UDPStats>();
 
   cluon::UDPReceiver monitor_receiver("127.0.0.1", monitor_port,

--- a/test/test_integration.sh
+++ b/test/test_integration.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+echo "Running integration tests..."
+set -e
+set -o pipefail
+set -u
+set -o errtrace
+set -o functrace
+set -o posix
+set -o noclobber
+
+# Allow for silent failure if mccode-antlr is not installed
+if ! command -v mcstas-antlr &> /dev/null; then
+    echo "mcstas-antlr not found, skipping integration tests."
+    exit 100
+fi
+if ! command -v ./readout-config&> /dev/null; then
+    echo "local readout-config not found."
+    exit 1
+fi
+compdir=$(./readout-config --show compdir)
+
+# Switch to a temporary directory
+#tmpdir=$(mktemp -d)
+#trap 'rm -rf -- "${tmpdir}"' EXIT
+#cd ${tmpdir} || exit 1
+# Create a temporary file for the test
+temp_file="test_instrument.instr"
+# And give it some content
+/bin/cat <<EOF > "$temp_file"
+DEFINE INSTRUMENT test_instrument(int dummy=0)
+USERVARS
+%{
+int RING;
+int FEN;
+int TUBE;
+int A;
+int B;
+double tof;
+%}
+
+TRACE
+SEARCH "${compdir}"
+COMPONENT origin = Arm() AT (0, 0, 0) ABSOLUTE
+EXTEND
+%{
+RING = 0;
+FEN = 0;
+TUBE = 0;
+A = 0;
+B = 0;
+tof = 0.0;
+%}
+
+COMPONENT readout = ReadoutCAEN(
+  ring="RING", fen="FEN", tube="TUBE", event_mode="p", a_name="A", b_name="B", tof="tof", ip="127.0.0.1", port=9000,
+  broadcast=0
+  )
+  AT (0, 0, 0) ABSOLUTE
+
+COMPONENT monitor_readout = ReadoutTTLMonitor(
+  ring="RING", fen="FEN", position="A", identity="TUBE", value="B", tof="tof", ip="127.0.0.1", port=9001, broadcast=0
+)
+  AT (0, 0, 0) ABSOLUTE
+
+END
+EOF
+
+# Convert the test file into a C file
+mcstas-antlr ${temp_file} || exit 1
+# Compile the C file and run it
+mcrun-antlr ${temp_file} -n 1 dummy=1 || exit 1
+
+exit 0


### PR DESCRIPTION
Update the compiled tester to use a system-assigned port for its receivers, so that if the port is already in use the test can still succeed. 

Add a simple compiled instrument test which includes the components, to ensure that translation and compilation is possible.
Further tests could help ensure that the runtime behavior of the components and the readout library work as expected too.

A few issues with both components were uncovered via the new test, and those errors have been fixed.
At present the test will not run on GitHub Actions due to a missing dependency on `mccode-antlr` -- this can be turned on once an unrelated mccode-antlr &harr; McCode version problem is resolved.