### PR TITLE
[Fix] missed change to component directory in #16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,5 +170,5 @@ install(FILES "${PROJECT_BINARY_DIR}/ReadoutConfigVersion.cmake" "${PROJECT_BINA
 configure_file("${PROJECT_SOURCE_DIR}/cmake/readout_config.h.in" "${CMAKE_BINARY_DIR}/readout_config.h" @ONLY)
 
 # Copy the component file to the include directory too
-file(GLOB ALL_COMPONENTS "${CMAKE_CURRENT_SOURCE_DIR}/components/*.comp")
+file(GLOB ALL_COMPONENTS "${CMAKE_CURRENT_SOURCE_DIR}/share/Readout/*.comp")
 install(FILES ${ALL_COMPONENTS} DESTINATION ${Readout_DATADIR})


### PR DESCRIPTION
Without this change running `cmake ... --target install` did not produce a fully usable installation, since the components were not copied.